### PR TITLE
Update forestry to allow game to start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ if (ENV.BUILD_NUMBER) {
 group= "vswe.stevescarts" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 
 minecraft {
-	version = "1.12.2-14.23.0.2493"
+	version = "1.12.2-14.23.0.2500"
 	mappings = "snapshot_20170624"
 	replace "@MODVERSION@", project.version
 	//  makeObfSourceJar = false
@@ -56,7 +56,7 @@ repositories {
 
 
 dependencies {
-	deobfCompile ('net.sengir.forestry:forestry_1.12:+'){
+	deobfCompile ('net.sengir.forestry:forestry_1.12.2:+'){
 		transitive = false
 	}
 	compile ('RebornCore:RebornCore-1.12.2:+:dev'){


### PR DESCRIPTION
The forestry version specified only allows for minecraft 1.12 and 1.12.1, and wont let you start the game