### PR TITLE
Fixes NullPointerException in PacketFluidSync

### DIFF
--- a/src/main/java/vswe/stevescarts/packet/PacketFluidSync.java
+++ b/src/main/java/vswe/stevescarts/packet/PacketFluidSync.java
@@ -50,8 +50,10 @@ public class PacketFluidSync implements INetworkPacket<PacketFluidSync> {
 	@Override
 	public void processData(PacketFluidSync message, MessageContext context) {
 		if(context.side == Side.CLIENT){
-			TileEntityLiquid liquid = (TileEntityLiquid) Minecraft.getMinecraft().world.getTileEntity(message.pos);
-			liquid.tanks[message.tankID].setFluid(message.fluidStack);
+			TileEntity tile = Minecraft.getMinecraft().world.getTileEntity(message.pos);
+			if(tile!=null && tile instanceof TileEntityLiquid){
+				((TileEntityLiquid)tile).tanks[message.tankID].setFluid(message.fluidStack);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a crash when a PacketFluidSync is sent to nearby players but the player doesn't have the Tile loaded.
Currently when someone opens the Fluid Inventory GUI players hundreds of blocks away crash.
Seems inefficient that someone not opening GUI is receiving a packet at this point?

The client crash = https://pastebin.com/jyh7kg46